### PR TITLE
Slightly better visualization for the published image.

### DIFF
--- a/src/SemiDenseTracking.cpp
+++ b/src/SemiDenseTracking.cpp
@@ -1116,7 +1116,9 @@ void show_error1( cv::Mat points3D_cam, cv::Mat image,  cv::Mat image_print, int
 
            if (k<num_pixels_sd2project )
            {
-               image_print.at<cv::Vec3b>(yy,xx)[2] = round(190.0*weight.at<double>(k,0));
+               image_print.at<cv::Vec3b>(yy,xx)[2] = round(255-255*weight.at<double>(k,0));      //R
+        	   image_print.at<cv::Vec3b>(yy,xx)[0] = round(255-255*weight.at<double>(k,0));      //B
+        	   image_print.at<cv::Vec3b>(yy,xx)[1] = round(255*weight.at<double>(k,0));          //G
            }
            else
            {image_print.at<cv::Vec3b>(yy,xx)[0] = 255;}


### PR DESCRIPTION
Right now the marker color looks just red. I edited it a little bit so that low-error pixels look green, and high-error pixels (mostly occlusion) look pink. Not a critical change.